### PR TITLE
Change behaviour to create petco2hrf fmri proxy due to the SPC of average signal being more robust than average of SPC

### DIFF
--- a/phys2cvr/phys2cvr.py
+++ b/phys2cvr/phys2cvr.py
@@ -322,13 +322,9 @@ def phys2cvr(fname_func, fname_co2=None, fname_pidx=None, fname_roi=None, fname_
                 LGR.warning('No filter applied to the input average! You know '
                             'what you are doing, right?')
 
-            petco2hrf = signal.spc(func_avg)
-        elif func_is_nifti:
-            # Get the average of the SPC rather than the SPC of the average
-            if apply_filter:
-                petco2hrf = signal.spc(func_filt[roi]).mean(axis=0)
-            else:
-                petco2hrf = signal.spc(func[roi]).mean(axis=0)
+        # Get the SPC of the average rather than the average of the SPC
+        # The former is more robust to intrinsic data noise than the latter
+        petco2hrf = signal.spc(func_avg)
 
         # Reassign fname_co2 to fname_func for later use - calling splitext twice cause .gz
         basename_co2 = os.path.splitext(os.path.splitext(f'avg_{os.path.basename(fname_func)}')[0])[0]

--- a/phys2cvr/signal.py
+++ b/phys2cvr/signal.py
@@ -43,7 +43,7 @@ def spc(ts):
     m = ts.mean(axis=-1)[..., np.newaxis]
     md = deepcopy(m)
     md[md == 0] = 1
-    ts = (ts - m) / md.T
+    ts = (ts - m) / md
     ts[np.isnan(ts)] = 0
 
     return ts


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Superseeds #44 and fix #45

<!-- Add a short description of the PR content here-->
Before the program was computing the average of the signal percentage change as an fMRI only proxy of CO2.
Now it's computing the SPC of the average since the latter solution is more robust to intrinsic noise, while the former was providing bad timeseries.

This might change in the future.

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  -
  -
  -

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
