### PR TITLE
Add option to add orthogonalised regressors in phys2cvr

### DIFF
--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -395,6 +395,42 @@ def _get_parser():
         default=None,
     )
     opt_regr.add_argument(
+        "-omat",
+        "--orthogonalised-matrix",
+        dest="orthogonalised_matrix",
+        nargs="*",
+        type=str,
+        help=(
+            "Complete path (absolute or relative) and filename "
+            "of denoising matrices to add to the regression model, "
+            "but only after they have been orthogonalised w.r.t. "
+            "denoising matrices and extra matrices (-dmat and -emat "
+            "flags). This option can be specified multiple times to "
+            "add multiple matrices, but multiple "
+            "matrices can be specified one after "
+            "the other, separated by a space."
+        ),
+        default=None,
+    )
+    opt_regr.add_argument(
+        "-emat",
+        "--extra-orthogonal-matrix",
+        dest="extra_matrix",
+        nargs="*",
+        type=str,
+        help=(
+            "Complete path (absolute or relative) and filename "
+            "of matrices to use to orthogonalise other denoising matrices with. "
+            "These matrices will not be added as regressors in the regression, "
+            "but only used for orthogonalisation purposes."
+            "This option can be specified multiple times to "
+            "add multiple matrices, but multiple "
+            "matrices can be specified one after "
+            "the other, separated by a space."
+        ),
+        default=None,
+    )
+    opt_regr.add_argument(
         "-scale",
         "--scale-factor",
         dest="scale_factor",

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -381,7 +381,7 @@ def _get_parser():
     opt_regr.add_argument(
         "-dmat",
         "--denoise-matrix",
-        dest="denoise_matrix",
+        dest="denoise_matrix_file",
         nargs="*",
         type=str,
         help=(
@@ -397,7 +397,7 @@ def _get_parser():
     opt_regr.add_argument(
         "-omat",
         "--orthogonalised-matrix",
-        dest="orthogonalised_matrix",
+        dest="orthogonalised_matrix_file",
         nargs="*",
         type=str,
         help=(
@@ -415,7 +415,7 @@ def _get_parser():
     opt_regr.add_argument(
         "-emat",
         "--extra-orthogonal-matrix",
-        dest="extra_matrix",
+        dest="extra_matrix_file",
         nargs="*",
         type=str,
         help=(

--- a/phys2cvr/phys2cvr.py
+++ b/phys2cvr/phys2cvr.py
@@ -84,7 +84,7 @@ def phys2cvr(
 ):
     """
     Run main workflow of phys2cvr.
-    
+
     Parameters
     ----------
     fname_func : str or path
@@ -217,7 +217,7 @@ def phys2cvr(
     debug : bool, optional
         Return to screen more output.
         Default: False
-    
+
     Raises
     ------
     ValueError
@@ -562,7 +562,15 @@ def phys2cvr(
         LGR.info("Compute simple CVR estimation (bulk shift only)")
         x1D = os.path.join(outdir, "mat", "mat_simple.1D")
         beta, tstat, r_square = stats.regression(
-            func, regr, denoise_matrix, orthogonalised_matrix, extra_matrix, mask, r2model, debug, x1D
+            func,
+            regr,
+            denoise_matrix,
+            orthogonalised_matrix,
+            extra_matrix,
+            mask,
+            r2model,
+            debug,
+            x1D,
         )
 
         LGR.info("Export bulk shift results")
@@ -660,7 +668,7 @@ def phys2cvr(
                         regr,
                         denoise_matrix,
                         orthogonalised_matrix,
-                        extra_matrix, 
+                        extra_matrix,
                         [lag_idx == i],
                         r2model,
                         debug,
@@ -700,7 +708,15 @@ def phys2cvr(
                         tstat_all[:, :, :, n],
                         r_square_all[:, :, :, n],
                     ) = stats.regression(
-                        func, regr, denoise_matrix, orthogonalised_matrix, extra_matrix, mask, r2model, debug, x1D
+                        func,
+                        regr,
+                        denoise_matrix,
+                        orthogonalised_matrix,
+                        extra_matrix,
+                        mask,
+                        r2model,
+                        debug,
+                        x1D,
                     )
 
                 if debug:

--- a/phys2cvr/stats.py
+++ b/phys2cvr/stats.py
@@ -346,7 +346,7 @@ def get_legendre(degree, length):
 def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
     """
     Implement Ordinary Least Square linear regression.
-    
+
     Both Ymat and Xmat must encode the time axis in axis 0.
     This is the barebone OLS implementation. For the full regression step,
     see `stats.regression`.
@@ -394,7 +394,7 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
         T-stats values
     r_square : np.ndarray
         R^2 values
-    
+
     Raises
     ------
     NotImplementedError
@@ -405,11 +405,15 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
         If a non-valid R^2 value is declared
     """
     if Ymat.ndim > 2:
-        raise NotImplementedError('OLS on data with more than 2 dimensions is not implemented yet.')
+        raise NotImplementedError(
+            "OLS on data with more than 2 dimensions is not implemented yet."
+        )
     elif Ymat.ndim < 2:
         Ymat = Ymat[..., np.newaxis]
     if Xmat.ndim > 2:
-        raise NotImplementedError('OLS with regressors with more than 2 dimensions is not implemented yet.')
+        raise NotImplementedError(
+            "OLS with regressors with more than 2 dimensions is not implemented yet."
+        )
     elif Xmat.ndim < 2:
         Xmat = Xmat[..., np.newaxis]
 
@@ -424,8 +428,8 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
 
     except np.linalg.LinAlgError:
         raise ValueError(
-            'The given matrices might not be oriented correctly. Try to transpose the '
-            'regressor matrix.'
+            "The given matrices might not be oriented correctly. Try to transpose the "
+            "regressor matrix."
         )
 
     if residuals:
@@ -492,9 +496,7 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
             r2msg = r2model
         if "adj_" in r2model:
             # We could compute ADJUSTED R^2 instead
-            r_square = 1 - (
-                (1 - r_square) * (Xmat.shape[0] - 1) / (df - 1)
-            )
+            r_square = 1 - ((1 - r_square) * (Xmat.shape[0] - 1) / (df - 1))
             r2msg = f"adjusted {r2msg}"
 
         LGR.info(f"Adopting {r2msg} baseline to compute R^2.")
@@ -503,7 +505,15 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
 
 
 def regression(
-    data, regr, denoise_mat=None, ortho_mat=None, extra_mat=None, mask=None, r2model="full", debug=False, x1D="mat.1D"
+    data,
+    regr,
+    denoise_mat=None,
+    ortho_mat=None,
+    extra_mat=None,
+    mask=None,
+    r2model="full",
+    debug=False,
+    x1D="mat.1D",
 ):
     """
     Estimate regression parameters.

--- a/phys2cvr/stats.py
+++ b/phys2cvr/stats.py
@@ -611,7 +611,7 @@ def regression(
         np.savetxt(x1D, Xmat, fmt="%.6f")
 
     betas, tstats, r_square = ols(
-        Ymat, Xmat, r2model="full", residuals=False, demean=False
+        Ymat.T, Xmat, r2model="full", residuals=False, demean=False
     )
 
     # Assign betas, Rsquare and tstats to new volume

--- a/phys2cvr/stats.py
+++ b/phys2cvr/stats.py
@@ -601,7 +601,8 @@ def regression(
                         )
                 orthogonalising_mat = np.hstack([orthogonalising_mat, extra_mat])
 
-            ortho_mat = ols(ortho_mat, orthogonalising_mat, residuals=True)
+            ortho_mat = ortho_mat - ortho_mat.mean(axis=0)
+            ortho_mat = ols(ortho_mat, orthogonalising_mat, residuals=True, demean=True)
             Xmat = np.hstack([ortho_mat, Xmat])
     else:
         Xmat = regr
@@ -611,7 +612,7 @@ def regression(
         np.savetxt(x1D, Xmat, fmt="%.6f")
 
     betas, tstats, r_square = ols(
-        Ymat.T, Xmat, r2model="full", residuals=False, demean=False
+        Ymat.T, Xmat, r2model="full", residuals=False, demean=True
     )
 
     # Assign betas, Rsquare and tstats to new volume

--- a/phys2cvr/stats.py
+++ b/phys2cvr/stats.py
@@ -601,8 +601,7 @@ def regression(
                         )
                 orthogonalising_mat = np.hstack([orthogonalising_mat, extra_mat])
 
-            ortho_mat = ortho_mat - ortho_mat.mean(axis=0)
-            ortho_mat = ols(ortho_mat, orthogonalising_mat, residuals=True, demean=True)
+            ortho_mat = ols(ortho_mat, orthogonalising_mat, residuals=True)
             Xmat = np.hstack([ortho_mat, Xmat])
     else:
         Xmat = regr
@@ -612,7 +611,7 @@ def regression(
         np.savetxt(x1D, Xmat, fmt="%.6f")
 
     betas, tstats, r_square = ols(
-        Ymat.T, Xmat, r2model="full", residuals=False, demean=True
+        Ymat.T, Xmat, r2model="full", residuals=False, demean=False
     )
 
     # Assign betas, Rsquare and tstats to new volume

--- a/phys2cvr/stats.py
+++ b/phys2cvr/stats.py
@@ -356,26 +356,26 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
     Ymat : np.ndarray
         Dependent variable, 1D or 2D
     Xmat : np.ndarray
-        Independent variables, 1D or 2D
+        Independent variables, 1D or 2D. The regressor of interest MUST be the last one.
     r2model : {'full', 'partial', 'intercept', 'adj_full', 'adj_partial', 'adj_intercept'}, optional
         R^2 to report.
         Possible models are:
             - 'full' (default)
                 Use every regressor in the model, i.e. compare versus baseline 0
             - 'partial'
-                Consider only `regr` in the model, i.e. compare versus baseline
-                composed by all other regressors (`mat_conf`)
+                Consider only the first vector of Xmat in the model, i.e. compare
+                versus baseline composed by all vectors of Xmat beside the first.
             - 'intercept'
                 Use every regressor in the model, but the intercept, i.e. compare
                 versus baseline intercept (Legendre polynomial order 0, a.k.a.
                 average signal)
             - 'adj_*'
-                Adjusted R^2 version of normal counterpart
+                Adjusted R^2 version of simple counterpart
         Under normal conditions, while the R^2 value will be different between options,
         a lagged regression based on any R^2 model will give the same results.
-        This WILL NOT be the case if orthogonalisations between `regr` and `mat_conf`
-        are introduced: a lagged regression based on `partial` might hold different
-        results.
+        This WILL NOT be the case if orthogonalisations between the first vector of Xmat
+        and the others are introduced: a lagged regression based on `partial` might hold
+        different results from .
         Default: 'full'
     residuals : bool, optional
         If True, output only residuals of the model - this is mainly for orthogonalisation
@@ -383,18 +383,24 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
     demean : bool, optional
         If True, demean Xmat before running OLS.
         Default is False.
-    
+
     Returns
     -------
-    TYPE
-        Description
+    betas : np.ndarray
+        Beta values
+    t_stats : np.ndarray
+        T-stats values
+    r_square : np.ndarray
+        R^2 values
     
     Raises
     ------
     NotImplementedError
-        Description
+        If Ymat has more than 2 dimensions
+        If Xmat has more than 2 dimensions
+        At the moment, if "poly" R^2 is declared, as it's not implemented yet.
     ValueError
-        Description
+        If a non-valid R^2 value is declared
     """
     if Ymat.ndim > 2:
         raise NotImplementedError('OLS on data with more than 2 dimensions is not implemented yet.')
@@ -402,7 +408,7 @@ def ols(Ymat, Xmat, r2model="full", residuals=False, demean=False):
         raise NotImplementedError('OLS with regressors with more than 2 dimensions is not implemented yet.')
 
     if demean:
-        Xmat = Xmat-Xmat.mean(axis=0)
+        Xmat = Xmat - Xmat.mean(axis=0)
 
     betas, RSS, _, _ = np.linalg.lstsq(Xmat, Ymat.T, rcond=None)
 

--- a/phys2cvr/stats.py
+++ b/phys2cvr/stats.py
@@ -590,7 +590,7 @@ def regression(
                         "the dimensionality of the PetCO2hrf regressor!"
                     )
 
-            orthogonalising_mat = Xmat.copy()
+            nuisance_mat = Xmat.copy()
             if extra_mat is not None:
                 if extra_mat.shape[0] != denoise_mat.shape[0]:
                     extra_mat = extra_mat.T
@@ -599,9 +599,9 @@ def regression(
                             "The provided extra matrix does not match "
                             "the dimensionality of the PetCO2hrf regressor!"
                         )
-                orthogonalising_mat = np.hstack([orthogonalising_mat, extra_mat])
+                nuisance_mat = np.hstack([nuisance_mat, extra_mat])
 
-            ortho_mat = ols(ortho_mat, orthogonalising_mat, residuals=True)
+            ortho_mat = ols(ortho_mat, nuisance_mat, residuals=True)
             Xmat = np.hstack([ortho_mat, Xmat])
     else:
         Xmat = regr
@@ -613,6 +613,9 @@ def regression(
     betas, tstats, r_square = ols(
         Ymat.T, Xmat, r2model="full", residuals=False, demean=False
     )
+    if debug:
+        # debug should eport betas, tstats, r_square
+        pass
 
     # Assign betas, Rsquare and tstats to new volume
     bout = mask * 1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ doc =
     myst-parser
 style =
     flake8 >=4.0
-    black <23.0.0
+    black
     isort <6.0.0
     pydocstyle
 test =


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Closes #81 

<!-- Add a short description of the PR content here-->
This PR adds the possibility of adding denoising matrices that will be orthogonalised internally by phys2cvr, following the methods in Moia et al. 2021 (Neuroimage).
Also contains a bit of refactoring of the `stats` submodule

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Refactor `stats`, moving OLS computation to its own function and adding the possibility to return residuals instead of full stats
  - Add the possibility to specify a matrix (omat) that is orthogonalised w.r.t. the regressor of interest and all other denoising regressor matrices (dmat) and extra matrices that will not be added to the regression after (emat).
  - Update the CLI consequently.
  - This PR implements the "aggressive", "conservative", and "moderate" approach described in Moia et al. 2021.

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
