### PR TITLE
Fix bandpass Butterworth filter order to get a better filter, add option to change order in CLI

### DIFF
--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -260,6 +260,14 @@ def _get_parser():
         ),
         default=None,
     )
+    opt_filt.add_argument(
+        "-bo",
+        "--butter-order",
+        dest="butter_order",
+        type=int,
+        help=("Order of Butterworth filter. Default is 9."),
+        default=None,
+    )
 
     opt_flow = parser.add_argument_group("Optional Arguments to modify the workflow")
     opt_flow.add_argument(

--- a/phys2cvr/phys2cvr.py
+++ b/phys2cvr/phys2cvr.py
@@ -62,8 +62,9 @@ def phys2cvr(
     n_trials=None,
     abs_xcorr=False,
     skip_xcorr=False,
-    highcut=None,
-    lowcut=None,
+    highcut=0.04,
+    lowcut=0.02,
+    butter_order=9,
     apply_filter=False,
     run_regression=False,
     lagged_regression=True,
@@ -140,11 +141,14 @@ def phys2cvr(
     highcut : str, int, or float, optional
         High frequency limit for filter.
         Required if applying a filter.
-        Default: empty
+        Default: 0.02
     lowcut : str, int, or float, optional
         Low frequency limit for filter.
         Required if applying a filter.
-        Default: empty
+        Default: 0.04
+    butter_order : int, optional
+        Butterworth filter order.
+        Default: 9
     apply_filter : bool, optional
         Apply a Butterworth filter to the functional input.
         Default: False
@@ -322,7 +326,9 @@ def phys2cvr(
             LGR.info(f"Loading {fname_func}")
             if apply_filter:
                 LGR.info("Applying butterworth filter to {fname_func}")
-                func_avg = signal.filter_signal(func_avg, tr, lowcut, highcut)
+                func_avg = signal.filter_signal(
+                    func_avg, tr, lowcut, highcut, butter_order
+                )
         else:
             raise NameError(
                 "Provided functional signal, but no TR specified! "
@@ -372,7 +378,7 @@ def phys2cvr(
 
         if apply_filter:
             LGR.info(f"Obtaining filtered average signal in {roiref}")
-            func_filt = signal.filter_signal(func, tr, lowcut, highcut)
+            func_filt = signal.filter_signal(func, tr, lowcut, highcut, butter_order)
             func_avg = func_filt[roi].mean(axis=0)
         else:
             LGR.info(f"Obtaining average signal in {roiref}")

--- a/phys2cvr/signal.py
+++ b/phys2cvr/signal.py
@@ -90,7 +90,7 @@ def create_hrf(freq=40):
     return hrf
 
 
-def filter_signal(data, tr, lowcut="", highcut=""):
+def filter_signal(data, tr, lowcut=0.02, highcut=0.04, order=9):
     """
     Create a bandpass filter given a lowcut and a highcut, then filter data.
 
@@ -104,20 +104,18 @@ def filter_signal(data, tr, lowcut="", highcut=""):
         Lower frequency in the bandpass
     highcut : float
         Higher frequency in the bandpass
+    order : int
+        The order of the butterworth filter
 
     Returns
     -------
     filt_data : np.ndarray
         Input `data`, but filtered.
     """
-    if not lowcut:
-        lowcut = 0.02
-    if not highcut:
-        highcut = 0.04
     nyq = (1 / tr) / 2
     low = lowcut / nyq
     high = highcut / nyq
-    a, b = butter(1, [low, high], btype="band")
+    a, b = butter(order, [low, high], btype="band")
     filt_data = filtfilt(a, b, data, axis=-1)
     return filt_data
 


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->

Addresses and possibly fixes #89 
@farnazdelavari if you can test again the new version of the code vs your matlab impementation, I'd appreciate it.

<!-- Add a short description of the PR content here-->


## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Changes default Butterworth filter order from 1 to 9 to get a steeper change
  - Add option to change order in filter function, workflow, and CLI

Not super-happy about how the power spectra post-filtering looks like, a bit more work might be needed here!

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
