### PR TITLE
Add the option to use an asymmetrical lag range

### DIFF
--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -480,13 +480,28 @@ def _get_parser():
         dest='lag_max',
         type=float,
         help=(
-            'Maximum lag to consider during lag regression in seconds. The same lag '
-            'will be considered in both directions.\nDespite the code being python, the '
-            'upper limit is included in the computation. E.g. -lm 9 -ls .3 means '
-            '[-9, +9] (61 regressors).'
+            'Maximum (most positive) lag to consider during lag regression in seconds. '
+            'If --lag-min is not specified, the same lag will be considered in both '
+            'directions (symmetric range).\n'
+            'Despite the code being python, the upper limit is included in the computation. '
+            'E.g., -lm 9 -ls .3 means [-9, +9] (61 regressors). '
+            'E.g., -lmin -6 -lm 9 -ls .3 means [-6, +9] (51 regressors).'
         ),
         default=None,
     )
+    opt_lreg.add_argument(
+        '-lmin',
+        '--lag-min',
+        dest='lag_min',
+        type=float,
+        help=(
+            'Minimum (most negative) lag to consider during lag regression in seconds. '
+            'If not specified, defaults to -lag_max (symmetric range).\n'
+            'Use this to specify asymmetric lag ranges. E.g., -lmin -6 -lm 9 -ls .3 '
+            'means [-6, +9] (51 regressors).'
+        ),
+        default=None,
+        )
     opt_lreg.add_argument(
         '-ls',
         '--lag-step',
@@ -686,6 +701,8 @@ def _check_opt_conf(parser):
                 'In fact, you should not see this message at all.'
             )
 
+    if parser.lag_min is None  and parser.lag_max is not None:
+        parser.lag_min = -1*float(parser.lag_max)
     if parser.r2model is None:
         parser.r2model = 'full'
 

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -501,7 +501,7 @@ def _get_parser():
             'means [-6, +9] (51 regressors).'
         ),
         default=None,
-        )
+    )
     opt_lreg.add_argument(
         '-ls',
         '--lag-step',
@@ -701,8 +701,8 @@ def _check_opt_conf(parser):
                 'In fact, you should not see this message at all.'
             )
 
-    if parser.lag_min is None  and parser.lag_max is not None:
-        parser.lag_min = -1*float(parser.lag_max)
+    if parser.lag_min is None and parser.lag_max is not None:
+        parser.lag_min = -1 * float(parser.lag_max)
     if parser.r2model is None:
         parser.r2model = 'full'
 

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -483,10 +483,8 @@ def _get_parser():
         type=float,
         help=(
             'Maximum (i.e. latest) lag to consider during lag regression, expressed in seconds. '
-            'If `-lmin` is not specified, the opposite value will be considered as minimum (i.e. earliest) lag.\n'
-            'The two limits (positive and negative) are both included in the computation.'
-            'E.g., -lm 9 -ls .3 means [-9, +9] (61 regressors). '
-            'E.g., -lmin -6 -lm 9 -ls .3 means [-6, +9] (51 regressors).'
+            'If `-lmin` is not specified, the opposite of the maximum lag will be considered the minimum (i.e. earliest) lag.\n'
+            'E.g., -lm 9 -ls .3 means [-9, +9] (61 regressors) and -lmin -6 -lm 9 -ls .3 means [-6, +9] (51 regressors) . '
         ),
         default=None,
     )

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -495,7 +495,7 @@ def _get_parser():
         type=float,
         help=(
             'Minimum (i.e. earliest) lag to consider during lag regression, expressed in seconds. '
-            'If not specified, it will be the opposite value of `lmax`, so the considered lag range will be symmetric around the coarse temporal realignemnt.\n'
+            'If not specified and `lmax` is positive, it will be the opposite value of `lmax`, so the considered lag range will be symmetric around the coarse temporal realignment.\n'
             'Use this to specify asymmetric lag ranges. E.g., -lmin -6 -lm 9 -ls .3 '
             'means [-6, +9] (51 regressors).'
         ),

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -476,9 +476,9 @@ def _get_parser():
     opt_lreg = parser.add_argument_group('Optional Arguments for the lagged regression')
     opt_lreg.add_argument(
         '-lm',
-'-lmax',
-'--lag-max',
-'-lm',
+        '-lmax',
+        '--lag-max',
+        '-lm',
         dest='lag_max',
         type=float,
         help=(
@@ -706,7 +706,9 @@ def _check_opt_conf(parser):
         if parser.lag_max > 0:
             parser.lag_min = -1 * float(parser.lag_max)
         else:
-            raise ValueError('Given max lag max is negative, but no min lag was provided. Halting execution.')  
+            raise ValueError(
+                'Given max lag max is negative, but no min lag was provided. Halting execution.'
+            )
     if parser.r2model is None:
         parser.r2model = 'full'
 

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -483,7 +483,7 @@ def _get_parser():
         type=float,
         help=(
             'Maximum (i.e. latest) lag to consider during lag regression, expressed in seconds. '
-            'If `-lmin` is not specified, the opposite value will be considered as minimum (i.e. earnest) lag.\n'
+            'If `-lmin` is not specified, the opposite value will be considered as minimum (i.e. earliest) lag.\n'
             'Despite the code being python, the upper limit is included in the computation. '
             'E.g., -lm 9 -ls .3 means [-9, +9] (61 regressors). '
             'E.g., -lmin -6 -lm 9 -ls .3 means [-6, +9] (51 regressors).'
@@ -496,8 +496,8 @@ def _get_parser():
         dest='lag_min',
         type=float,
         help=(
-            'minimum (i.e. earnest) lag to consider during lag regression, expressed in seconds. '
-            'If not specified, defaults to -lag_max (symmetric range).\n'
+            'Minimum (i.e. earliest) lag to consider during lag regression, expressed in seconds. '
+            'If not specified, it will be the opposite value of `lmax`, so the considered lag range will be symmetric around the coarse temporal realignemnt.\n'
             'Use this to specify asymmetric lag ranges. E.g., -lmin -6 -lm 9 -ls .3 '
             'means [-6, +9] (51 regressors).'
         ),

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -476,13 +476,14 @@ def _get_parser():
     opt_lreg = parser.add_argument_group('Optional Arguments for the lagged regression')
     opt_lreg.add_argument(
         '-lm',
-        '--lag-max',
+'-lmax',
+'--lag-max',
+'-lm',
         dest='lag_max',
         type=float,
         help=(
-            'Maximum (most positive) lag to consider during lag regression in seconds. '
-            'If --lag-min is not specified, the same lag will be considered in both '
-            'directions (symmetric range).\n'
+            'Maximum (i.e. latest) lag to consider during lag regression, expressed in seconds. '
+            'If `-lmin` is not specified, the opposite value will be considered as minimum (i.e. earnest) lag.\n'
             'Despite the code being python, the upper limit is included in the computation. '
             'E.g., -lm 9 -ls .3 means [-9, +9] (61 regressors). '
             'E.g., -lmin -6 -lm 9 -ls .3 means [-6, +9] (51 regressors).'
@@ -495,7 +496,7 @@ def _get_parser():
         dest='lag_min',
         type=float,
         help=(
-            'Minimum (most negative) lag to consider during lag regression in seconds. '
+            'minimum (i.e. earnest) lag to consider during lag regression, expressed in seconds. '
             'If not specified, defaults to -lag_max (symmetric range).\n'
             'Use this to specify asymmetric lag ranges. E.g., -lmin -6 -lm 9 -ls .3 '
             'means [-6, +9] (51 regressors).'
@@ -702,7 +703,10 @@ def _check_opt_conf(parser):
             )
 
     if parser.lag_min is None and parser.lag_max is not None:
-        parser.lag_min = -1 * float(parser.lag_max)
+        if parser.lag_max > 0:
+            parser.lag_min = -1 * float(parser.lag_max)
+        else:
+            raise ValueError('Given max lag max is negative, but no min lag was provided. Halting execution.')  
     if parser.r2model is None:
         parser.r2model = 'full'
 

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -709,7 +709,9 @@ def _check_opt_conf(parser):
             )
 
     if parser.lag_max is None and parser.lag_min is not None:
-        raise ValueError('A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.')
+        raise ValueError(
+            'A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.'
+        )
 
     if parser.r2model is None:
         parser.r2model = 'full'

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -705,8 +705,12 @@ def _check_opt_conf(parser):
             parser.lag_min = -1 * float(parser.lag_max)
         else:
             raise ValueError(
-                'Given max lag max is negative, but no min lag was provided. Halting execution.'
+                'Given maximum lag is negative, but no minimum lag was provided. Halting execution.'
             )
+
+    if parser.lag_max is None and parser.lag_min is not None:
+        raise ValueError('A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.')
+
     if parser.r2model is None:
         parser.r2model = 'full'
 

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -484,7 +484,7 @@ def _get_parser():
         help=(
             'Maximum (i.e. latest) lag to consider during lag regression, expressed in seconds. '
             'If `-lmin` is not specified, the opposite value will be considered as minimum (i.e. earliest) lag.\n'
-            'Despite the code being python, the upper limit is included in the computation. '
+            'The two limits (positive and negative) are both included in the computation.'
             'E.g., -lm 9 -ls .3 means [-9, +9] (61 regressors). '
             'E.g., -lmin -6 -lm 9 -ls .3 means [-6, +9] (51 regressors).'
         ),

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -705,7 +705,7 @@ def _check_opt_conf(parser):
             parser.lag_min = -1 * float(parser.lag_max)
         else:
             raise ValueError(
-                'Given maximum lag is negative, but no minimum lag was provided. Halting execution.'
+                'Given maximum lag is 0 or negative, but no minimum lag was provided. Halting execution.'
             )
 
     if parser.lag_max is None and parser.lag_min is not None:

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -478,7 +478,6 @@ def _get_parser():
         '-lm',
         '-lmax',
         '--lag-max',
-        '-lm',
         dest='lag_max',
         type=float,
         help=(

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -434,4 +434,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -281,10 +281,9 @@ def create_fine_shift_regressors(
 
     # Padding regressor right for shifts if not enough timepoints
     # Padding regressor left for shifts and update optshift if less than neg_shifts.
-    rpad = max(0, func_upsamp_size + optshift + pos_shifts - petco2hrf.shape[0])
-    lpad = max(0, neg_shifts - optshift)
-    print(f'lpad = {lpad}')
-    print(f'rpad = {rpad}')
+    rpad = max(0, int(func_upsamp_size + optshift + neg_shifts - petco2hrf.shape[0]))
+    lpad = max(0, int(pos_shifts - optshift + 1))
+
     petco2hrf = np.pad(petco2hrf, (int(lpad), int(rpad)), 'mean')
 
     # Create sliding window view into petco2hrf, -1 because of reversed indexing

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -294,6 +294,7 @@ def create_fine_shift_regressors(
     pos_idx = optshift + neg_shifts + lpad - 1
     # select the right windows the other way round
     petco2hrf_lagged = swv(petco2hrf, func_upsamp_size)[pos_idx:neg_idx:-1].copy()
+    
     petco2hrf_lagged = export_regressor(
         petco2hrf_lagged, func_size, outprefix, 'shifts', ext
     )

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -294,7 +294,7 @@ def create_fine_shift_regressors(
     pos_idx = optshift + neg_shifts + lpad - 1
     # select the right windows the other way round
     petco2hrf_lagged = swv(petco2hrf, func_upsamp_size)[pos_idx:neg_idx:-1].copy()
-    
+
     petco2hrf_lagged = export_regressor(
         petco2hrf_lagged, func_size, outprefix, 'shifts', ext
     )

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -251,10 +251,14 @@ def create_fine_shift_regressors(
         Regressor of interest
     optshift : int
         The index shift computed by the Xcorr/bulk shift
-    lag_max : int or float, optional
-       Higher limit of the temporal area to explore, expressed in seconds.
-    lag_min : int or float
+    lag_max : int, float, or None, optional
+        Upper limit of the temporal area to explore, expressed in seconds.
+        Caution: this is not a pythonic range, but a real range, i.e. the upper limit is included.
+        Default: None
+    lag_min : int, float, or None, optional
         Lower limit of the temporal area to explore, expressed in seconds.
+        If set to None, and lag_max is not None and is positive, lag_min defaults to -lag_max (symmetric range).
+        Default: None
     freq : str, int, or float
         Sample frequency of petco2hrf
     func_size : int
@@ -332,13 +336,14 @@ def create_physio_regressor(
         Sample frequency of petco2hrf
     outprefix : list or path
         Path to output directory for computed regressors.
-    lag_max : int or float, optional
-        Limits (both positive and negative) for the estimated temporal lag,
-        expressed in seconds.
-        Default: 9 (i.e., -9 to +9 seconds)
-    lag_min : int or float, optional
-        Lower limit for the estimated temporal lag, expressed in seconds.
-        Default: -lag_max
+    lag_max : int, float, or None, optional
+        Upper limit of the temporal area to explore, expressed in seconds.
+        Caution: this is not a pythonic range, but a real range, i.e. the upper limit is included.
+        Default: None
+    lag_min : int, float, or None, optional
+        Lower limit of the temporal area to explore, expressed in seconds.
+        If set to None, and lag_max is not None and is positive, lag_min defaults to -lag_max (symmetric range).
+        Default: None
     trial_len : str or int, optional
         Length of each individual trial for timeseries which include more than one trial
         (e.g., multiple BreathHold trials, trials within CO2 challenges, ...)

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -281,7 +281,7 @@ def create_fine_shift_regressors(
     outprefix = os.path.join(regr_dir, base)
 
     neg_shifts = int(abs(lag_min) * freq)
-    pos_shifts = int(lag_max * freq) if legacy else int(lag_max * freq) + 1
+    pos_shifts = int(abs(lag_max) * freq) if legacy else int(abs(lag_max) * freq) + 1
 
     # Padding regressor right for shifts if not enough timepoints
     # Padding regressor left for shifts and update optshift if less than neg_shifts.

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -252,8 +252,7 @@ def create_fine_shift_regressors(
     optshift : int
         The index shift computed by the Xcorr/bulk shift
     lag_max : int or float, optional
-        Limits (both positive and negative) of the temporal area to explore,
-        expressed in seconds.
+       Higher limit of the temporal area to explore, expressed in seconds.
     lag_min : int or float
         Lower limit of the temporal area to explore, expressed in seconds.
     freq : str, int, or float

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -276,8 +276,24 @@ def create_fine_shift_regressors(
     Returns
     -------
     petco2hrf_lagged : np.ndarray
-        The shifted versions of the regresosr of interest.
+        The shifted versions of the regressor of interest.
     """
+    if lag_max is not None and lag_min is None:
+        if lag_max>0:
+            lag_min = -lag_max
+        else:
+            raise ValueError(
+                'Given maximum lag is 0 or negative, but no minimum lag was provided. Halting execution.'
+            )
+            
+    if lag_max is None and lag_min is not None:
+        raise ValueError('A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.')
+        
+    if lag_max is not None and lag_min >= lag_max:
+        raise ValueError(
+            f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max}). Please provide a range where lag_min < lag_max.'
+        )
+        
     outdir, base = os.path.split(outprefix)
     regr_dir = os.path.join(outdir, 'regr')
     os.makedirs(regr_dir, exist_ok=True)

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -279,21 +279,23 @@ def create_fine_shift_regressors(
         The shifted versions of the regressor of interest.
     """
     if lag_max is not None and lag_min is None:
-        if lag_max>0:
+        if lag_max > 0:
             lag_min = -lag_max
         else:
             raise ValueError(
                 'Given maximum lag is 0 or negative, but no minimum lag was provided. Halting execution.'
             )
-            
+
     if lag_max is None and lag_min is not None:
-        raise ValueError('A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.')
-        
+        raise ValueError(
+            'A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.'
+        )
+
     if lag_max is not None and lag_min >= lag_max:
         raise ValueError(
             f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max}). Please provide a range where lag_min < lag_max.'
         )
-        
+
     outdir, base = os.path.split(outprefix)
     regr_dir = os.path.join(outdir, 'regr')
     os.makedirs(regr_dir, exist_ok=True)

--- a/phys2cvr/tests/conftest.py
+++ b/phys2cvr/tests/conftest.py
@@ -37,10 +37,8 @@ def fetch_file(osf_id, path, filename):
     # this three lines make tests downloads work in windows
     if os.name == 'nt':
         orig_sslsocket_init = ssl.SSLSocket.__init__
-        ssl.SSLSocket.__init__ = (
-            lambda *args, cert_reqs=ssl.CERT_NONE, **kwargs: orig_sslsocket_init(
-                *args, cert_reqs=ssl.CERT_NONE, **kwargs
-            )
+        ssl.SSLSocket.__init__ = lambda *args, cert_reqs=ssl.CERT_NONE, **kwargs: (
+            orig_sslsocket_init(*args, cert_reqs=ssl.CERT_NONE, **kwargs)
         )
         ssl._create_default_https_context = ssl._create_unverified_context
     url = f'https://osf.io/{osf_id}/download'

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -310,7 +310,7 @@ def phys2cvr(
     l_degree = utils.if_declared_force_type(l_degree, 'int', 'l_degree')
     if lag_min >= lag_max:
         raise ValueError(
-            f"Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max})"
+            f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max})'
         )
     if l_degree < 0:
         raise ValueError(
@@ -513,7 +513,7 @@ def phys2cvr(
 
             if lag_max is None:
                 lag_max = np.asarray(lag_list).max()
-                lag_min= np.asarray(lag_list).min()
+                lag_min = np.asarray(lag_list).min()
                 LGR.warning(f'phys2cvr detected a lag range of [{lag_min}, {lag_max}]')
             else:
                 LGR.warning(f'Forcing lag range to be [{lag_min}, {lag_max}]')

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -149,14 +149,13 @@ def phys2cvr(
         will change results with orthogonalisations.
         See `stats.ols` help for more details.
         Default: `full`
-    lag_min : int, float, or None, optional
-        Lower limit of the temporal area to explore, expressed in seconds.
-        Caution: this is not a pythonic range, but a real range, i.e. the lower limit is included.
-        If set to None, and lag_max is not None, lag_min defaults to -lag_max (symmetric range).
-        Default: None
     lag_max : int, float, or None, optional
         Upper limit of the temporal area to explore, expressed in seconds.
         Caution: this is not a pythonic range, but a real range, i.e. the upper limit is included.
+        Default: None
+    lag_min : int, float, or None, optional
+        Lower limit of the temporal area to explore, expressed in seconds.
+        If set to None, and lag_max is not None, lag_min defaults to -lag_max (symmetric range).
         Default: None
     lag_step : int, float, or None, optional
         Step of the lag to take into account in seconds.

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -49,8 +49,8 @@ def phys2cvr(
     run_regression=False,
     lagged_regression=True,
     r2model='full',
-    lag_min=None,
     lag_max=None,
+    lag_min=None,
     lag_step=None,
     legacy=False,
     l_degree=0,
@@ -303,8 +303,8 @@ def phys2cvr(
     n_trials = utils.if_declared_force_type(n_trials, 'int', 'n_trials')
     highcut = utils.if_declared_force_type(highcut, 'float', 'highcut')
     lowcut = utils.if_declared_force_type(lowcut, 'float', 'lowcut')
-    lag_min = utils.if_declared_force_type(lag_min, 'float', 'lag_min')
     lag_max = utils.if_declared_force_type(lag_max, 'float', 'lag_max')
+    lag_min = utils.if_declared_force_type(lag_min, 'float', 'lag_min')
     lag_step = utils.if_declared_force_type(lag_step, 'float', 'lag_step')
     l_degree = utils.if_declared_force_type(l_degree, 'int', 'l_degree')
     if lag_min >= lag_max:

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -471,7 +471,7 @@ def phys2cvr(
 
         petco2hrf = compute_petco2hrf(
             co2, pidx, freq, outprefix, comp_endtidal, response_function
-            )
+        )
     # If the user provided a lag map, read it and extract information from it
     if lag_map:
         LGR.info('Load lag map')
@@ -504,7 +504,6 @@ def phys2cvr(
             LGR.warning(f'phys2cvr detected a lag range of [{lag_min}, {lag_max}]')
         else:
             LGR.warning(f'Forcing lag range to be [{lag_min}, {lag_max}]')
-
 
     # If a regressor dir is specified, try load the data,
     # If failing or otherwise, compute the regressors.

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -323,6 +323,7 @@ def phys2cvr(
         raise ValueError(
             f'R^2 model {r2model} not supported. Supported models are {stats.R2MODEL}'
         )
+        
     LGR.info('Load functional data')
     if func_is_1d:
         if tr:
@@ -396,6 +397,7 @@ def phys2cvr(
         if apply_filter:
             LGR.info(f'Obtaining filtered average signal in {roiref}')
             func_avg = signal.filter_signal(func_avg, tr, lowcut, highcut, butter_order)
+            
     LGR.info('Load physiological data')
     if fname_co2 is None:
         LGR.info(f'Computing "CVR" (approximation) maps using {fname_func} only')
@@ -445,6 +447,7 @@ def phys2cvr(
             else:
                 # pidx to None for compatibility
                 pidx = None
+                
             if freq is None:
                 raise NameError(
                     f'{fname_co2} file is a text file, but no '
@@ -475,6 +478,7 @@ def phys2cvr(
         petco2hrf = compute_petco2hrf(
             co2, pidx, freq, outprefix, comp_endtidal, response_function
         )
+        
     # If the user provided a lag map, read it and extract information from it
     if lag_map:
         LGR.info('Load lag map')
@@ -497,6 +501,7 @@ def phys2cvr(
                         f'phys2cvr found different delta lags in {lag_map}: {lag_step}'
                     )
             lag_step = lag_step[0]
+            
             LGR.warning(f'phys2cvr detected a delta lag of {lag_step} seconds')
         else:
             LGR.warning(f'Forcing delta lag to be {lag_step}')
@@ -635,6 +640,7 @@ def phys2cvr(
                 )
 
                 step = int(lag_step * freq)
+                
                 lag_idx = np.round((lag + lag_max) * freq / step).astype(int)
                 lag_idx_list = np.unique(lag_idx)
 
@@ -665,6 +671,7 @@ def phys2cvr(
                     f'Running lagged CVR estimation with lag range = [{lag_min}, {lag_max}]! '
                     '(might take a while...)'
                 )
+                
                 if legacy:
                     nrep_neg = int(abs(lag_min) * freq)
                     nrep_pos = int(abs(lag_max) * freq)

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -323,7 +323,7 @@ def phys2cvr(
         raise ValueError(
             f'R^2 model {r2model} not supported. Supported models are {stats.R2MODEL}'
         )
-        
+
     LGR.info('Load functional data')
     if func_is_1d:
         if tr:
@@ -397,7 +397,7 @@ def phys2cvr(
         if apply_filter:
             LGR.info(f'Obtaining filtered average signal in {roiref}')
             func_avg = signal.filter_signal(func_avg, tr, lowcut, highcut, butter_order)
-            
+
     LGR.info('Load physiological data')
     if fname_co2 is None:
         LGR.info(f'Computing "CVR" (approximation) maps using {fname_func} only')
@@ -447,7 +447,7 @@ def phys2cvr(
             else:
                 # pidx to None for compatibility
                 pidx = None
-                
+
             if freq is None:
                 raise NameError(
                     f'{fname_co2} file is a text file, but no '
@@ -478,7 +478,7 @@ def phys2cvr(
         petco2hrf = compute_petco2hrf(
             co2, pidx, freq, outprefix, comp_endtidal, response_function
         )
-        
+
     # If the user provided a lag map, read it and extract information from it
     if lag_map:
         LGR.info('Load lag map')
@@ -501,7 +501,7 @@ def phys2cvr(
                         f'phys2cvr found different delta lags in {lag_map}: {lag_step}'
                     )
             lag_step = lag_step[0]
-            
+
             LGR.warning(f'phys2cvr detected a delta lag of {lag_step} seconds')
         else:
             LGR.warning(f'Forcing delta lag to be {lag_step}')
@@ -640,7 +640,7 @@ def phys2cvr(
                 )
 
                 step = int(lag_step * freq)
-                
+
                 lag_idx = np.round((lag + lag_max) * freq / step).astype(int)
                 lag_idx_list = np.unique(lag_idx)
 
@@ -671,7 +671,7 @@ def phys2cvr(
                     f'Running lagged CVR estimation with lag range = [{lag_min}, {lag_max}]! '
                     '(might take a while...)'
                 )
-                
+
                 if legacy:
                     nrep_neg = int(abs(lag_min) * freq)
                     nrep_pos = int(abs(lag_max) * freq)

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -232,6 +232,7 @@ def phys2cvr(
             to have different lag_steps inside.
         - If the maximum lag is 0 or negative and no minimum lag is provided
         - If a minimum lag is provided and no maximum lag is provided
+        - If the minimum lag is greater than or equal to the maximum lag
     NotImplementedError
         - If a file type is not supported yet.
     NameError

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -310,7 +310,7 @@ def phys2cvr(
     lag_min = utils.if_declared_force_type(lag_min, 'float', 'lag_min')
     lag_step = utils.if_declared_force_type(lag_step, 'float', 'lag_step')
     l_degree = utils.if_declared_force_type(l_degree, 'int', 'l_degree')
-    if lag_min >= lag_max:
+    if lag_max is not None and lag_min >= lag_max:
         raise ValueError(
             f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max})'
         )

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -393,7 +393,7 @@ def phys2cvr(
         if apply_filter:
             LGR.info(f'Obtaining filtered average signal in {roiref}')
             func_avg = signal.filter_signal(func_avg, tr, lowcut, highcut, butter_order)
-L   LGR.info('Load physiological data')
+    LGR.info('Load physiological data')
     if fname_co2 is None:
         LGR.info(f'Computing "CVR" (approximation) maps using {fname_func} only')
         if func_is_1d:

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -640,7 +640,7 @@ def phys2cvr(
 
                 step = int(lag_step * freq)
 
-                lag_idx = np.round((lag + lag_max) * freq / step).astype(int)
+                lag_idx = np.round((lag - lag_min) * freq / step).astype(int)
                 lag_idx_list = np.unique(lag_idx)
 
                 # Prepare empty matrices

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -155,7 +155,7 @@ def phys2cvr(
         Default: None
     lag_min : int, float, or None, optional
         Lower limit of the temporal area to explore, expressed in seconds.
-        If set to None, and lag_max is not None, lag_min defaults to -lag_max (symmetric range).
+        If set to None, and lag_max is not None and is positive, lag_min defaults to -lag_max (symmetric range).
         Default: None
     lag_step : int, float, or None, optional
         Step of the lag to take into account in seconds.

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -662,6 +662,7 @@ def phys2cvr(
                 LGR.info(
                     f'Running lagged CVR estimation with lag range = [{lag_min}, {lag_max}]! '
                     '(might take a while...)'
+                )
                 if legacy:
                     nrep_neg = int(abs(lag_min) * freq)
                     nrep_pos = int(abs(lag_max) * freq)

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -230,6 +230,8 @@ def phys2cvr(
             functional nifti file.
         - If a lag map was specified, lag_step was not, and the lag map seems
             to have different lag_steps inside.
+        - If the maximum lag is 0 or negative and no minimum lag is provided
+        - If a minimum lag is provided and no maximum lag is provided
     NotImplementedError
         - If a file type is not supported yet.
     NameError

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -312,7 +312,7 @@ def phys2cvr(
     l_degree = utils.if_declared_force_type(l_degree, 'int', 'l_degree')
     if lag_max is not None and lag_min >= lag_max:
         raise ValueError(
-            f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max})'
+            f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max}). Please provide a range where lag_min < lag_max.'
         )
     if l_degree < 0:
         raise ValueError(

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -303,7 +303,6 @@ def phys2cvr(
     n_trials = utils.if_declared_force_type(n_trials, 'int', 'n_trials')
     highcut = utils.if_declared_force_type(highcut, 'float', 'highcut')
     lowcut = utils.if_declared_force_type(lowcut, 'float', 'lowcut')
-    lowcut = utils.if_declared_force_type(lowcut, 'float', 'lowcut')
     lag_min = utils.if_declared_force_type(lag_min, 'float', 'lag_min')
     lag_max = utils.if_declared_force_type(lag_max, 'float', 'lag_max')
     lag_step = utils.if_declared_force_type(lag_step, 'float', 'lag_step')

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -149,16 +149,16 @@ def phys2cvr(
         will change results with orthogonalisations.
         See `stats.ols` help for more details.
         Default: `full`
-    lag_min : int or float, optional
+    lag_min : int, float, or None, optional
         Lower limit of the temporal area to explore, expressed in seconds.
         Caution: this is not a pythonic range, but a real range, i.e. the lower limit is included.
-        If None, defaults to -lag_max (symmetric range).
-        Default: -lag_max
-    lag_max : int or float, optional
+        If set to None, and lag_max is not None, lag_min defaults to -lag_max (symmetric range).
+        Default: None
+    lag_max : int, float, or None, optional
         Upper limit of the temporal area to explore, expressed in seconds.
         Caution: this is not a pythonic range, but a real range, i.e. the upper limit is included.
         Default: None
-    lag_step : int or float, optional
+    lag_step : int, float, or None, optional
         Step of the lag to take into account in seconds.
         Default: None
     legacy : bool, optional

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -310,14 +310,16 @@ def phys2cvr(
     lag_step = utils.if_declared_force_type(lag_step, 'float', 'lag_step')
     l_degree = utils.if_declared_force_type(l_degree, 'int', 'l_degree')
     if lag_max is not None and lag_min is None:
-        if lag_max>0:
+        if lag_max > 0:
             lag_min = -lag_max
         else:
             raise ValueError(
                 'Given maximum lag is 0 or negative, but no minimum lag was provided. Halting execution.'
             )
     if lag_max is None and lag_min is not None:
-        raise ValueError('A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.')
+        raise ValueError(
+            'A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.'
+        )
     if lag_max is not None and lag_min >= lag_max:
         raise ValueError(
             f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max}). Please provide a range where lag_min < lag_max.'

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -309,6 +309,15 @@ def phys2cvr(
     lag_min = utils.if_declared_force_type(lag_min, 'float', 'lag_min')
     lag_step = utils.if_declared_force_type(lag_step, 'float', 'lag_step')
     l_degree = utils.if_declared_force_type(l_degree, 'int', 'l_degree')
+    if lag_max is not None and lag_min is None:
+        if lag_max>0:
+            lag_min = -lag_max
+        else:
+            raise ValueError(
+                'Given maximum lag is 0 or negative, but no minimum lag was provided. Halting execution.'
+            )
+    if lag_max is None and lag_min is not None:
+        raise ValueError('A minimum lag was provided without providing a maximum lag. Please rerun providing both or none.')
     if lag_max is not None and lag_min >= lag_max:
         raise ValueError(
             f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max}). Please provide a range where lag_min < lag_max.'


### PR DESCRIPTION
Close #124 

## Proposed Changes
This PR has the same goal as #124, which is to allow for an asymmetrical shift range (i.e., allow the absolute lag min to be different from the absolute lag max), but that code is updated to be compatible with the current phys2cvr code. I tested this code by:

- creating lag maps with a [-5,10] shift range using the code in #124 , and verifying that those lag maps looked the same as those generated using the updated code in this PR
- creating lag maps with a [-10,10] shift range and verifying that those lag maps looked the same as those generated using the existing main phys2cvr code
- creating lag maps using the shift range [-5,5] and [-5,10] and confirming that only voxels whose estimated lag increased beyond 5s showed a change in lag value
- verifying that if the lag minimum is greater than the lag maximum, the code fails 

If lag_min is not specified, it defaults to -1*lag_max. The maximum lag can still be specified using the existing -lm (or --lag-max) argument, and the minimum lag is specified using -lmin (or --lag-min). While renaming -lm to -lmax could reduce ambiguity in the future, I kept it as is for now to ensure backwards compatibility.

It would be helpful if someone else could test this before we merge!

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [x] I added everything I wanted to add to this PR.
- [x] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [x] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [x] Please, comment on my PR while it's a draft and give me feedback on the development!
