### PR TITLE
Implementing an iterative delay correction strategy to improve CVR estimation in clinical populations

### DIFF
--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -512,6 +512,34 @@ def _get_parser():
         default=None,
     )
     opt_lreg.add_argument(
+        '-slm',
+        '--starting-lag-max',
+        dest='starting_lag_max',
+        type=float,
+        help=(
+            'Initial upper limit of the temporal area to explore, expressed in seconds. '
+            'If this value is specified, it is used as the initial upper limit of the search range for '
+            'identifying the optimal lag. If the optimal lag of a voxel '
+            'is within 1 lag step of starting-lag-max, the maximum lag for that voxel will be gradually '
+            'increase by the amount specified with --lag-increment until the optimal lag '
+            'is not at within 1 lag step of the maximum or it reaches --lag-max, whichever comes first. '
+            'E.g., --starting-lag-max 9 -lag-max 15 --lag-increment 2 starts at 9s and will expand to 9, 11, 13 and 15s if needed.'
+        ),
+        default=None,
+    )
+    
+    opt_lreg.add_argument(
+        '-li',
+        '--lag-increment',
+        dest='lag_increment',
+        type=float,
+        help=(
+            'Step size (in seconds) to increase the maximum lag when the optimal lag is within 1 lag step '
+            'of the boundary.  This value needs to be specified if starting_lag_max is not None.'
+        ),
+        default=None,
+    )
+    opt_lreg.add_argument(
         '--legacy',
         dest='legacy',
         action='store_true',

--- a/phys2cvr/cli/run.py
+++ b/phys2cvr/cli/run.py
@@ -520,9 +520,9 @@ def _get_parser():
             'Initial upper limit of the temporal area to explore, expressed in seconds. '
             'If this value is specified, it is used as the initial upper limit of the search range for '
             'identifying the optimal lag. If the optimal lag of a voxel '
-            'is within 1 lag step of starting-lag-max, the maximum lag for that voxel will be gradually '
-            'increase by the amount specified with --lag-increment until the optimal lag '
-            'is not at within 1 lag step of the maximum or it reaches --lag-max, whichever comes first. '
+            'is within 1 lag step of the minimum or starting maximum lag, the maximum lag for that voxel will be iteratively '
+            'increased by the amount specified with --lag-increment until the optimal lag '
+            'is not at within 1 lag step of the boundary or --lag-max is reached, whichever comes first. '
             'E.g., --starting-lag-max 9 -lag-max 15 --lag-increment 2 starts at 9s and will expand to 9, 11, 13 and 15s if needed.'
         ),
         default=None,
@@ -535,7 +535,7 @@ def _get_parser():
         type=float,
         help=(
             'Step size (in seconds) to increase the maximum lag when the optimal lag is within 1 lag step '
-            'of the boundary.  This value needs to be specified if starting_lag_max is not None.'
+            'of a boundary (minimum or maximum).  This value needs to be specified if starting_lag_max is not None.'
         ),
         default=None,
     )

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -456,7 +456,7 @@ def select_lag_avoid_boundary(
     expand_by=2,
 ):
     """
-    Iteratively expand the maximum shift only in voxels with lag values at the boundaries.
+    Expand the maximum shift only in voxels with lag values at the boundaries.
 
     Parameters
     ----------

--- a/phys2cvr/regressors.py
+++ b/phys2cvr/regressors.py
@@ -445,6 +445,92 @@ def create_physio_regressor(
     return petco2hrf_demean, petco2hrf_lagged
 
 
+def select_lag_avoid_boundary(
+    r_square_all,
+    mask,
+    starting_max,
+    final_max,
+    lag_min,
+    lag_step,
+    freq,
+    expand_by=2,
+):
+    """
+    Iteratively expand the maximum shift only in voxels with lag values at the boundaries.
+
+    Parameters
+    ----------
+    r_square_all : ndarray
+        R^2 values with shape (..., N_lags)
+    mask : ndarray
+        Boolean or 0/1 mask of valid voxels
+    starting_max : float
+        Initial maximum temporal shift to explore, expressed in seconds.
+        Caution: this is not a pythonic range, but a real range, i.e. the upper limit is included.
+        Default: None
+    final_max : float
+        Hard upper limit of the temporal area to explore, expressed in seconds.
+        Caution: this is not a pythonic range, but a real range, i.e. the upper limit is included.
+        Default: None
+    lag_min : int, float, or None, optional
+        Lower limit of the temporal area to explore, expressed in seconds.
+        If set to None, and lag_max is not None and is positive, lag_min defaults to -lag_max (symmetric range).
+        Default: None
+    lag_step : float
+        Lag step in seconds
+    freq : float
+        Sampling frequency (Hz)
+    expand_by : float, optional
+        Amount (seconds) to expand the lag window each iteration
+
+    Returns
+    -------
+    final_lag_idx : ndarray
+        Selected lag indices per voxel.
+    """
+
+    LGR.info(
+        f'Identifying optimal shifts using a starting maximum of {starting_max}s and a final maximum of {final_max}s. If needed, the starting maximum will be increased in increments of {expand_by}s.'
+    )
+
+    final_lag_idx = np.full(mask.shape, 0, dtype=int) #stores final lag indices
+    active = mask.astype(bool) #make all in mask voxels active
+    current_max = starting_max
+
+    while True:
+        # Convert lag (seconds) -> index
+        max_idx = int((current_max - lag_min) / lag_step)
+        boundary_idx = max_idx - 1
+
+        # Argmax only within current window
+        lag_idx = np.argmax(r_square_all[..., : max_idx + 1], axis=-1)
+        
+        # Identify voxels that hit the boundary
+        #at_boundary = (lag_idx >= boundary_idx) & active
+        at_boundary = ((lag_idx >= boundary_idx) | (lag_idx == 0) | (lag_idx == 1)) & active
+
+        # Accept non-boundary voxels and freeze them
+        frozen = active & ~at_boundary
+        final_lag_idx[frozen] = lag_idx[frozen]
+    
+        # Remove frozen voxels from active
+        active[frozen] = 0  # now only boundary voxels remain active
+    
+        # Keep only boundary-stuck voxels
+        active = active.astype(bool)  # ensure it's boolean
+
+        if not np.any(active):
+            break
+
+        if current_max + expand_by > final_max:
+            # Give up on remaining voxels
+            final_lag_idx[active] = lag_idx[active]
+            break
+
+        current_max += expand_by
+
+    return final_lag_idx
+
 """
 Copyright 2021-2026, Stefano Moia & phys2cvr contributors.
 

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -781,8 +781,21 @@ def phys2cvr(
                     )
 
                 # Find the right lag for CVR estimation
-                lag_idx = np.argmax(r_square_all, axis=-1)
-                lag = (lag_idx * step) / freq + (mask * lag_min)
+                if starting_lag_max is not None:
+                    lag_idx = select_lag_avoid_boundary(
+                        r_square_all=r_square_all,
+                        mask=mask,
+                        starting_max=starting_lag_max,
+                        final_max=lag_max,
+                        lag_min=lag_min,
+                        lag_step=lag_step,
+                        freq=freq,
+                        expand_by=lag_increment,
+                    )
+                    lag = (lag_idx * step) / freq + (mask * lag_min)
+                else:
+                    lag_idx = np.argmax(r_square_all, axis=-1)
+                    lag = (lag_idx * step) / freq + (mask * lag_min)
                 # Express lag map relative to median of the roi
                 lag_rel = lag - (mask * np.median(lag[roi]))
 

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -346,10 +346,10 @@ def phys2cvr(
         )
     if starting_lag_max is not None and lag_increment is None:
         raise ValueError(
-            f'You provided a value for the starting_lag_max but did not specify lag_increment, which determines
-            the step size for increasing the maximum lag. If you are going to specify starting_lag_max, 
-            please also specify lag_increment!'
-        )    
+            f"You provided a value for starting_lag_max but did not specify lag_increment, which determines "
+            "the step size for increasing the maximum lag. If you are going to specify starting_lag_max, "
+            "please also specify lag_increment!"
+        ) 
     if starting_lag_max>=lag_max:
         raise ValueError(
             f'If you are going to specify a starting_lag_max, it should be less than lag_max.'

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -168,9 +168,9 @@ def phys2cvr(
         Initial upper limit of the temporal area to explore, expressed in seconds. 
         If this value is specified, it is used as the initial upper limit of the search range for 
         identifying the optimal lag. If the optimal lag of a voxel
-        is within 1 lag step of starting-lag-max, the maximum lag for that voxel will be gradually
-        increase by the amount specified with --lag-increment until the optimal lag
-        is not at within 1 lag step of the maximum or it reaches --lag-max, whichever comes first.
+        is within 1 lag step of a boundary (either lag_min or starting-lag-max), the maximum lag for 
+        that voxel will be iteratively increased by the amount specified with --lag-increment until the optimal lag
+        is not at within 1 lag step of a boundary or --lag-max is reached, whichever comes first.
         Default: None
     lag_increment : int, float, or None, optional
         Step size (in seconds) to increase the maximum lag when the optimal lag is within 1 lag step

--- a/phys2cvr/workflows.py
+++ b/phys2cvr/workflows.py
@@ -23,6 +23,8 @@ from phys2cvr.regressors import (
     compute_petco2hrf,
     create_legendre,
     create_physio_regressor,
+    select_lag_avoid_boundary
+    
 )
 
 LGR = logging.getLogger(__name__)
@@ -52,6 +54,8 @@ def phys2cvr(
     lag_max=None,
     lag_min=None,
     lag_step=None,
+    starting_lag_max=None,
+    lag_increment=None,
     legacy=False,
     l_degree=0,
     denoise_matrix_file=None,
@@ -160,6 +164,18 @@ def phys2cvr(
     lag_step : int, float, or None, optional
         Step of the lag to take into account in seconds.
         Default: None
+    starting_lag_max : int, float, or None, optional
+        Initial upper limit of the temporal area to explore, expressed in seconds. 
+        If this value is specified, it is used as the initial upper limit of the search range for 
+        identifying the optimal lag. If the optimal lag of a voxel
+        is within 1 lag step of starting-lag-max, the maximum lag for that voxel will be gradually
+        increase by the amount specified with --lag-increment until the optimal lag
+        is not at within 1 lag step of the maximum or it reaches --lag-max, whichever comes first.
+        Default: None
+    lag_increment : int, float, or None, optional
+        Step size (in seconds) to increase the maximum lag when the optimal lag is within 1 lag step
+        of the boundary.  This value needs to be specified if starting_lag_max is not None.'
+        Default: None
     legacy : bool, optional
         If True, use pythonic ranges when creating the regressors, i.e. exclude
         the upper range (e.g. [-9, +9) ).
@@ -232,6 +248,10 @@ def phys2cvr(
         - If the maximum lag is 0 or negative and no minimum lag is provided
         - If a minimum lag is provided and no maximum lag is provided
         - If the minimum lag is greater than or equal to the maximum lag
+        - If a starting_lag_max is provided and no lag_increment is specified
+        - If a starting_lag_max is provided and it is greater than or equal to lag_max
+        - If a lag map is provided AND starting_lag_max is specified. (The lag map option does
+        not work with the iterative lag search)
     NotImplementedError
         - If a file type is not supported yet.
     NameError
@@ -324,6 +344,20 @@ def phys2cvr(
         raise ValueError(
             f'Invalid lag range: lag_min ({lag_min}) >= lag_max ({lag_max}). Please provide a range where lag_min < lag_max.'
         )
+    if starting_lag_max is not None and lag_increment is None:
+        raise ValueError(
+            f'You provided a value for the starting_lag_max but did not specify lag_increment, which determines
+            the step size for increasing the maximum lag. If you are going to specify starting_lag_max, 
+            please also specify lag_increment!'
+        )    
+    if starting_lag_max>=lag_max:
+        raise ValueError(
+            f'If you are going to specify a starting_lag_max, it should be less than lag_max.'
+        ) 
+    if lag_map is not None and starting_lag_max is not None:
+        raise ValueError(
+            f'The option to provide a lag map to calculate CVR is not supported with an iterative lag maximum.'
+        )    
     if l_degree < 0:
         raise ValueError(
             'The specified order of the Legendre polynomials must be >= 0.'


### PR DESCRIPTION
This code implements the iterative delay correction approach described in [this preprint](https://www.biorxiv.org/content/10.64898/2026.04.07.716988v2). This approach is useful for clinical cohorts when the appropriate maximum shift is not known. We found that using a maximum shift that is too small can result in many delay estimates at the boundary (meaning that they are probably not optimized), but a conservatively large maximum shift can result in spurious negative CVR values. To address this, the delay search range is selectively expanded only for voxels with estimated delays at a boundary (i.e., within 1 lag step of the minimum or maximum shift) until the estimated delay is no longer at a boundary or a predefined value is reached.

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Two new parameters were introduced: a starting maximum lag and an increment for increasing the maximum shift
  - If these parameters are defined, and a voxel's lag value is within 1 lag step of the minimum or starting maximum lag, the maximum lag for that voxel will be iteratively increased by the amount specified with --lag-increment until the optimal lag is not at within 1 lag step of the boundary or --lag-max (the final lag maximum) is reached, whichever comes first.
  - If a starting maximum lag is not defined, the iterative approach is not applied and the standard (fixed maximum) approach is used
  - Note that only the maximum lag is expanded, not the minimum lag. If the bulk shift is estimated from normal-appearing tissue or, in cases of pathology such as Moyamoya disease or carotid stenosis, from unaffected vascular territories, hemodynamic responses more than 9 s earlier than the bulk shift are not expected to be physiologically plausible (and thus an iterative expansion of the minimum lag would not be necessary). Rare exceptions like arteriovenous shunting would require additional modifications to the code.
  - An error is returned if:
        - A starting_lag_max is provided and no lag_increment is specified
        - A starting_lag_max is provided and it is greater than or equal to lag_max
        - A lag map is provided AND starting_lag_max is specified. (The lag map option does not work with the iterative lag search)


## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [x] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [x] I added everything I wanted to add to this PR.
- [x] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [x] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [x] Please, comment on my PR while it's a draft and give me feedback on the development!
